### PR TITLE
Dev ver 1.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.invvk</groupId>
     <artifactId>auto-increment-plugin</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>maven-plugin</packaging>
 
     <name>Version auto increment Plugin</name>

--- a/src/main/java/me/invvk/ModifyVersion.java
+++ b/src/main/java/me/invvk/ModifyVersion.java
@@ -25,27 +25,54 @@ public class ModifyVersion extends AbstractMojo {
     @Parameter(defaultValue = "false")
     protected boolean includeHash;
 
-    @Parameter(defaultValue = "LONG")
+    @Parameter(defaultValue = "SHORT")
     protected HashMode hashMode;
 
     @Parameter(defaultValue = "false")
-    protected boolean includeBuildNumber;
+    protected boolean includePatch;
 
     @Parameter(defaultValue = "9")
-    protected int buildNumLimit;
+    protected int patchLimit;
 
     @Parameter(defaultValue = "9")
     protected int minorLimit;
 
-    @Parameter(defaultValue = "false", property = "update.skip")
+    @Parameter(defaultValue = "false", property = "aip.skip")
     protected boolean skipUpdating;
+
+    @Parameter(defaultValue = "false", property = "aip.splitmode")
+    protected boolean splitMode;
+
+    @Parameter(defaultValue = "false", property = "aip.log")
+    protected boolean log;
 
     @Override
     public void execute() throws MojoExecutionException, MojoFailureException {
         VersionBuilder builder = new VersionBuilder.Builder(new VersionSettings(this)).build();
         if (builder == null)
             throw new MojoFailureException("Builder failed");
-        this.project.getProperties().put("autoincrement.version", builder.getFinalVersion());
-        getLog().info("autoincrement.version has been set to " + builder.getFinalVersion());
+
+        this.project.getProperties().put("aip.version.full", builder.getFinalVersion());
+
+
+        log("full version is " + builder.getFinalVersion());
+
+        if (splitMode) {
+            this.project.getProperties().put("aip.version.major", builder.getMajor());
+            this.project.getProperties().put("aip.version.minor", builder.getMinor());
+            this.project.getProperties().put("aip.version.patch", builder.getMajor());
+            this.project.getProperties().put("aip.version.commit", builder.getCommitHash());
+
+            log("major version is " + builder.getMajor());
+            log("minor version is " + builder.getMinor());
+            log("patch version is " + builder.getPatchNum());
+            log("full version is " + builder.getFinalVersion());
+        }
     }
+
+    private void log(String message) {
+        if (log)
+            getLog().info(message);
+    }
+
 }

--- a/src/main/java/me/invvk/ModifyVersion.java
+++ b/src/main/java/me/invvk/ModifyVersion.java
@@ -66,7 +66,7 @@ public class ModifyVersion extends AbstractMojo {
             log("major version is " + builder.getMajor());
             log("minor version is " + builder.getMinor());
             log("patch version is " + builder.getPatchNum());
-            log("full version is " + builder.getFinalVersion());
+            log("commit hash is " + builder.getCommitHash());
         }
     }
 

--- a/src/main/java/me/invvk/ModifyVersion.java
+++ b/src/main/java/me/invvk/ModifyVersion.java
@@ -70,9 +70,14 @@ public class ModifyVersion extends AbstractMojo {
         }
     }
 
-    private void log(String message) {
+    public void log(String message) {
         if (log)
             getLog().info(message);
+    }
+
+    public void error(String message, Throwable e) {
+        if (log)
+            getLog().error(message, e);
     }
 
 }

--- a/src/main/java/me/invvk/VersionBuilder.java
+++ b/src/main/java/me/invvk/VersionBuilder.java
@@ -66,11 +66,13 @@ public class VersionBuilder {
             try {
                 GitFile git = new GitFile(this.settings.getGit());
                 this.commitHash = this.settings.isShortHash() ? git.getShortCommitHash() : git.getCommitHash();
-                if (this.settings.isIncludeHash())
-                    builder.append("-").append(this.commitHash);
             } catch (MojoExecutionException e) {
-                e.printStackTrace();
+                settings.getInstance().error("Failed to load git file, hash commit will be ignored", e);
+                this.commitHash = "";
             }
+
+            if (this.settings.isIncludeHash())
+                builder.append("-").append(this.commitHash);
 
             this.finalVersion = builder.toString();
 

--- a/src/main/java/me/invvk/VersionBuilder.java
+++ b/src/main/java/me/invvk/VersionBuilder.java
@@ -8,18 +8,38 @@ import java.io.IOException;
 
 public class VersionBuilder {
 
-    private final String finalVersion;
+    private final String finalVersion,major,minor, patch,commitHash;
 
     private VersionBuilder(Builder builder) {
         this.finalVersion = builder.finalVersion;
+        this.major = builder.major;
+        this.minor = builder.minor;
+        this.patch = builder.patch;
+        this.commitHash = builder.commitHash;
     }
 
     public String getFinalVersion() {
         return finalVersion;
     }
 
+    public String getMajor() {
+        return major;
+    }
+
+    public String getMinor() {
+        return minor;
+    }
+
+    public String getPatchNum() {
+        return patch;
+    }
+
+    public String getCommitHash() {
+        return commitHash;
+    }
+
     public static final class Builder {
-        private String finalVersion;
+        private String finalVersion,major,minor, patch,commitHash;
         private final VersionSettings settings;
 
         public Builder(VersionSettings settings) {
@@ -35,19 +55,23 @@ public class VersionBuilder {
                 return null;
             }
             StringBuilder builder = new StringBuilder();
+            this.major = file.getMajor();
+            this.minor = file.getMinor();
+            this.patch = file.getPatch();
             builder.append(file.getMajor()).append(".").append(file.getMinor());
 
-            if (this.settings.isIncludeBuildNumber())
-                builder.append(".").append(file.getBuildNumber());
+            if (this.settings.isIncludePatch())
+                builder.append(".").append(file.getPatch());
 
-            if (this.settings.isIncludeHash()) {
-                try {
-                    GitFile git = new GitFile(this.settings.getGit());
-                    builder.append("-").append(this.settings.isShortHash() ? git.getShortCommitHash() : git.getCommitHash());
-                } catch (MojoExecutionException e) {
-                    e.printStackTrace();
-                }
+            try {
+                GitFile git = new GitFile(this.settings.getGit());
+                this.commitHash = this.settings.isShortHash() ? git.getShortCommitHash() : git.getCommitHash();
+                if (this.settings.isIncludeHash())
+                    builder.append("-").append(this.commitHash);
+            } catch (MojoExecutionException e) {
+                e.printStackTrace();
             }
+
             this.finalVersion = builder.toString();
 
             // Skip updating and only generate the file with the current version
@@ -55,10 +79,10 @@ public class VersionBuilder {
                 // updating version
                 int currMajor = Integer.parseInt(file.getMajor());
                 int currMinor = Integer.parseInt(file.getMinor());
-                int currBuildNum = Integer.parseInt(file.getBuildNumber());
+                int currPatchNum = Integer.parseInt(file.getPatch());
 
-                if (currBuildNum >= settings.getBuildNumberLimit()) {
-                    currBuildNum = 0;
+                if (currPatchNum >= settings.getBuildNumberLimit()) {
+                    currPatchNum = 0;
                     if (currMinor >= settings.getMinorLimit()) {
                         currMinor = 0;
                         currMajor += 1;
@@ -66,12 +90,12 @@ public class VersionBuilder {
                         currMinor += 1;
 
                 } else {
-                    currBuildNum += 1;
+                    currPatchNum += 1;
                 }
 
                 file.modify(file.MAJOR, String.valueOf(currMajor));
                 file.modify(file.MINOR, String.valueOf(currMinor));
-                file.modify(file.BUILD_NUMBER, String.valueOf(currBuildNum));
+                file.modify(file.PATCH, String.valueOf(currPatchNum));
                 // saving
                 file.save();
             }

--- a/src/main/java/me/invvk/VersionSettings.java
+++ b/src/main/java/me/invvk/VersionSettings.java
@@ -26,8 +26,8 @@ public class VersionSettings {
         return instance.storageName;
     }
 
-    public boolean isIncludeBuildNumber() {
-        return this.instance.includeBuildNumber;
+    public boolean isIncludePatch() {
+        return this.instance.includePatch;
     }
 
     public boolean isIncludeHash() {
@@ -43,7 +43,7 @@ public class VersionSettings {
     }
 
     public int getBuildNumberLimit() {
-        return this.instance.buildNumLimit;
+        return this.instance.patchLimit;
     }
 
     public int getMinorLimit() {

--- a/src/main/java/me/invvk/file/PropertyFile.java
+++ b/src/main/java/me/invvk/file/PropertyFile.java
@@ -11,7 +11,7 @@ public class PropertyFile {
     private final Properties properties = new Properties();
     private final File file;
 
-    public final String MAJOR = "major", MINOR = "minor", BUILD_NUMBER = "buildNum";
+    public final String MAJOR = "major", MINOR = "minor", PATCH = "patch";
 
     public PropertyFile(File basedir, String fileName) throws IOException {
         file = new File(basedir, fileName.endsWith(".properties") ? fileName : fileName + ".properties");
@@ -38,8 +38,13 @@ public class PropertyFile {
             changed = true;
         }
 
-        if (properties.getProperty(this.BUILD_NUMBER) == null) {
-            properties.setProperty(this.BUILD_NUMBER, "0");
+        if (properties.getProperty(this.PATCH) == null) {
+            String BUILD_NUMBER = "buildNum";
+            if (properties.getProperty(BUILD_NUMBER) != null) {
+                properties.setProperty(this.PATCH, properties.getProperty(BUILD_NUMBER));
+                properties.remove(BUILD_NUMBER);
+            } else
+                properties.setProperty(this.PATCH, "0");
             changed = true;
         }
 
@@ -64,8 +69,8 @@ public class PropertyFile {
         return this.properties.getProperty(this.MINOR);
     }
 
-    public String getBuildNumber() {
-        return this.properties.getProperty(this.BUILD_NUMBER);
+    public String getPatch() {
+        return this.properties.getProperty(this.PATCH);
     }
 
     public void modify(String key, String value) {


### PR DESCRIPTION
# New Options
 - Log option: enables or disables logging
 - Split mode: enables adding independent properties, current available: `aip.version.major`, `aip.version.minor`, `aip.version.patch`, `aip.version.commit`
 - added new maven command line properties: `aip.log` [BOOLEAN], `aip.split` [BOOLEAN]

# Changes
 - renamed BuildNum to patch (**IF YOU ARE USING `buildNumLimit` option in your configuration please change it to `patchLimit'**)
 - renamed properties from `version.{property}` to `aip.{property}`
 - default `hashMode` has been changed to `SHORT`